### PR TITLE
Add export options and thinning parameters

### DIFF
--- a/lib/fastlane/plugin/store_sizer/version.rb
+++ b/lib/fastlane/plugin/store_sizer/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module StoreSizer
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Hi!

I've been trying to add your plugin to our build config in order to measure and track app size. There are some parameters in our ExportOptions.plist file that we need to build, so I found it useful to have the plugin load those. Additionally, only thinning for a single device was necessary for us, so I added a param for that.

Would you be open to incorporating these changes?